### PR TITLE
[chore]: DB 설계 및 TypeORM DB Entity 생성

### DIFF
--- a/libs/common/config/validationSchema.ts
+++ b/libs/common/config/validationSchema.ts
@@ -5,4 +5,12 @@ export const ValidationSchema = Joi.object({
   PORT: Joi.string().required(),
   SWAGGER_ADMIN: Joi.string().required(),
   SWAGGER_PASSWORD: Joi.string().required(),
+  DB_HOST: Joi.string().required(),
+  DB_PORT: Joi.string().required(),
+  DB_NAME: Joi.string().required(),
+  DB_USERNAME: Joi.string().required(),
+  DB_PASSWORD: Joi.string().required(),
+  SYNCHRONIZE: Joi.string().required(),
+  LOGGING: Joi.string().required(),
+  DB_CONNECTION_TIMEOUT: Joi.string().required(),
 });

--- a/libs/entity/config/configService.ts
+++ b/libs/entity/config/configService.ts
@@ -7,8 +7,8 @@ import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 dotenv.config();
 
 class SwaggerAdminConfig {
-  readonly ADMIN_USER: string;
-  readonly ADMIN_PASSWORD: string;
+  readonly SWAGGER_ADMIN: string;
+  readonly SWAGGER_PASSWORD: string;
 }
 class DBConfig {
   readonly host: string;
@@ -28,8 +28,8 @@ export class ConfigService {
   }
 
   static swaggerAdminAuth(): SwaggerAdminConfig {
-    const { ADMIN_USER, ADMIN_PASSWORD } = process.env;
-    return { ADMIN_USER, ADMIN_PASSWORD };
+    const { SWAGGER_ADMIN, SWAGGER_PASSWORD } = process.env;
+    return { SWAGGER_ADMIN, SWAGGER_PASSWORD };
   }
 
   static ormConfig(): TypeOrmModuleOptions {

--- a/libs/entity/config/configService.ts
+++ b/libs/entity/config/configService.ts
@@ -1,11 +1,23 @@
 import { Injectable } from '@nestjs/common';
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import * as dotenv from 'dotenv';
+import * as path from 'path';
+import { SnakeNamingStrategy } from 'typeorm-naming-strategies';
 
 dotenv.config();
 
 class SwaggerAdminConfig {
   readonly ADMIN_USER: string;
   readonly ADMIN_PASSWORD: string;
+}
+class DBConfig {
+  readonly host: string;
+  readonly port: number;
+  readonly database: string;
+  readonly username: string;
+  readonly password: string;
+  readonly synchronize: boolean;
+  readonly logging: boolean;
 }
 
 @Injectable()
@@ -18,5 +30,53 @@ export class ConfigService {
   static swaggerAdminAuth(): SwaggerAdminConfig {
     const { ADMIN_USER, ADMIN_PASSWORD } = process.env;
     return { ADMIN_USER, ADMIN_PASSWORD };
+  }
+
+  static ormConfig(): TypeOrmModuleOptions {
+    return {
+      ...this.loadDBConfig(),
+      type: 'mysql',
+      entities: [path.join(__dirname, '..', 'domain/**/*.entity.{js,ts}')],
+      migrations: [path.join(__dirname, '..', 'migrations/*{.ts,.js}')],
+      cli: { migrationsDir: 'libs/entity/migrations' },
+      migrationsTableName: 'migrations',
+      autoLoadEntities: true,
+      keepConnectionAlive: true,
+      namingStrategy: new SnakeNamingStrategy(),
+      maxQueryExecutionTime: Number(process.env.DB_CONNECTION_TIMEOUT),
+    };
+  }
+
+  static loadDBConfig(): DBConfig {
+    const [host, port, username, password, database, logging, synchronize] =
+      process.env.NODE_ENV === 'production'
+        ? [
+            process.env.DB_HOST,
+            process.env.DB_PORT,
+            process.env.DB_USERNAME,
+            process.env.DB_PASSWORD,
+            process.env.DB_NAME,
+            process.env.LOGGING,
+            process.env.SYNCHRONIZE,
+          ]
+        : [
+            process.env.DB_LOCAL_HOST,
+            process.env.DB_LOCAL_PORT,
+            process.env.DB_LOCAL_USERNAME,
+            process.env.DB_LOCAL_PASSWORD,
+            process.env.DB_LOCAL_NAME,
+            process.env.LOCAL_LOGGING,
+            process.env.LOCAL_SYNCHRONIZE,
+          ];
+
+    return {
+      host,
+      port: Number(port),
+      database,
+      username,
+      password,
+      synchronize: synchronize === 'false' ? false : Boolean(synchronize),
+      logging: logging === 'false' ? false : Boolean(logging),
+    };
   }
 }

--- a/libs/entity/config/migrateConfig.ts
+++ b/libs/entity/config/migrateConfig.ts
@@ -1,0 +1,6 @@
+import { TypeOrmModuleOptions } from '@nestjs/typeorm';
+import { ConfigService } from './configService';
+
+const migrateConfig: TypeOrmModuleOptions = ConfigService.ormConfig();
+
+export = migrateConfig;

--- a/libs/entity/domain/BaseTimeEntity.ts
+++ b/libs/entity/domain/BaseTimeEntity.ts
@@ -1,0 +1,28 @@
+import {
+  CreateDateColumn,
+  Generated,
+  PrimaryColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { LocalDateTime, nativeJs } from 'js-joda';
+import { BigintValueTransformer } from '@app/entity/domain/transformer/BigintValueTransformer';
+
+export abstract class BaseTimeEntity {
+  @Generated('increment')
+  @PrimaryColumn({ type: 'bigint', transformer: new BigintValueTransformer() })
+  id: number;
+
+  @CreateDateColumn({ type: 'timestamptz', nullable: false })
+  createdAt: Date;
+
+  @UpdateDateColumn({ type: 'timestamptz', nullable: false })
+  updatedAt: Date;
+
+  getCreatedAt(): LocalDateTime {
+    return LocalDateTime.from(nativeJs(this.createdAt));
+  }
+
+  getUpdatedAt(): LocalDateTime {
+    return LocalDateTime.from(nativeJs(this.updatedAt));
+  }
+}

--- a/libs/entity/domain/BaseTimeEntity.ts
+++ b/libs/entity/domain/BaseTimeEntity.ts
@@ -12,10 +12,10 @@ export abstract class BaseTimeEntity {
   @PrimaryColumn({ type: 'bigint', transformer: new BigintValueTransformer() })
   id: number;
 
-  @CreateDateColumn({ type: 'timestamptz', nullable: false })
+  @CreateDateColumn({ type: 'timestamp', nullable: false })
   createdAt: Date;
 
-  @UpdateDateColumn({ type: 'timestamptz', nullable: false })
+  @UpdateDateColumn({ type: 'timestamp', nullable: false })
   updatedAt: Date;
 
   getCreatedAt(): LocalDateTime {

--- a/libs/entity/domain/country/Country.entity.ts
+++ b/libs/entity/domain/country/Country.entity.ts
@@ -1,0 +1,23 @@
+import { Column, Entity, OneToMany } from 'typeorm';
+import { BaseTimeEntity } from '../BaseTimeEntity';
+import { Product } from '../product/Product.entity';
+
+@Entity()
+export class Country extends BaseTimeEntity {
+  @Column({
+    unique: true,
+    nullable: false,
+  })
+  name: string;
+
+  @Column('decimal', { precision: 10, scale: 5, nullable: false })
+  exchangeRate: number;
+
+  @Column({
+    nullable: false,
+  })
+  currency: string;
+
+  @OneToMany(() => Product, (product: Product) => product.Country)
+  Product: Product[];
+}

--- a/libs/entity/domain/country/Country.module.ts
+++ b/libs/entity/domain/country/Country.module.ts
@@ -1,0 +1,11 @@
+import { Country } from '@app/entity/domain/country/Country.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Country])],
+  exports: [TypeOrmModule],
+  providers: [],
+  controllers: [],
+})
+export class CountryModule {}

--- a/libs/entity/domain/product/Product.entity.ts
+++ b/libs/entity/domain/product/Product.entity.ts
@@ -1,0 +1,62 @@
+import { Entity, JoinColumn, ManyToOne, Column, OneToMany } from 'typeorm';
+import { BaseTimeEntity } from '../BaseTimeEntity';
+import { Country } from '../country/Country.entity';
+import { Purchase } from '../purchase/Purchase.entity';
+import { BigintValueTransformer } from '../transformer/BigintValueTransformer';
+import { User } from '../user/User.entity';
+import { ProductStatus } from './ProductStatusType';
+
+@Entity()
+export class Product extends BaseTimeEntity {
+  @ManyToOne(() => User, (user: User) => user.ProductOwner, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'author_id', referencedColumnName: 'id' })
+  Author: User[] | User | number;
+
+  @ManyToOne(() => User, (user: User) => user.ProductInspect, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    nullable: true,
+  })
+  @JoinColumn({ name: 'editor_id', referencedColumnName: 'id' })
+  Editor: User[] | User | number;
+
+  @ManyToOne(() => Country, (country: Country) => country.Product, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'country_id', referencedColumnName: 'id' })
+  Country: Country[] | Country | string;
+
+  @Column({
+    default: ProductStatus.Pending,
+    nullable: false,
+  })
+  status: number;
+
+  @Column({
+    type: 'varchar',
+    nullable: false,
+  })
+  title: string;
+
+  @Column({
+    type: 'varchar',
+    nullable: false,
+  })
+  description: string;
+
+  @Column({
+    type: 'bigint',
+    transformer: new BigintValueTransformer(),
+    nullable: false,
+  })
+  price: number;
+
+  @OneToMany(() => Purchase, (purchase: Purchase) => purchase.Product)
+  Purchase: Purchase[];
+}

--- a/libs/entity/domain/product/Product.module.ts
+++ b/libs/entity/domain/product/Product.module.ts
@@ -1,0 +1,11 @@
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+import { Product } from './Product.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Product])],
+  exports: [TypeOrmModule],
+  providers: [],
+  controllers: [],
+})
+export class ProductModule {}

--- a/libs/entity/domain/product/ProductStatusType.ts
+++ b/libs/entity/domain/product/ProductStatusType.ts
@@ -1,0 +1,7 @@
+export const ProductStatus = {
+  Success: 1,
+  Fail: 2,
+  Pending: 3,
+} as const;
+
+export type ProductStatus = typeof ProductStatus[keyof typeof ProductStatus];

--- a/libs/entity/domain/purchase/Purchase.entity.ts
+++ b/libs/entity/domain/purchase/Purchase.entity.ts
@@ -1,0 +1,22 @@
+import { Entity, JoinColumn, ManyToOne } from 'typeorm';
+import { BaseTimeEntity } from '../BaseTimeEntity';
+import { Product } from '../product/Product.entity';
+import { User } from '../user/User.entity';
+
+@Entity()
+export class Purchase extends BaseTimeEntity {
+  @ManyToOne(() => User, (user: User) => user.ProductOwner, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+    nullable: false,
+  })
+  @JoinColumn({ name: 'user_id', referencedColumnName: 'id' })
+  User: User[] | User | number;
+
+  @ManyToOne(() => Product, (product: Product) => product.Purchase, {
+    onDelete: 'CASCADE',
+    onUpdate: 'CASCADE',
+  })
+  @JoinColumn({ name: 'product_id', referencedColumnName: 'id' })
+  Product: Product[] | Product | string;
+}

--- a/libs/entity/domain/purchase/Purchase.module.ts
+++ b/libs/entity/domain/purchase/Purchase.module.ts
@@ -1,0 +1,11 @@
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+import { Purchase } from './Purchase.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Purchase])],
+  exports: [TypeOrmModule],
+  providers: [],
+  controllers: [],
+})
+export class PurchaseModule {}

--- a/libs/entity/domain/transformer/BigintValueTransformer.ts
+++ b/libs/entity/domain/transformer/BigintValueTransformer.ts
@@ -1,0 +1,12 @@
+import { ValueTransformer } from 'typeorm';
+
+// TypeORM 에서 bigint 는 string 으로 처리됨
+export class BigintValueTransformer implements ValueTransformer {
+  to(entityValue: number): number {
+    return entityValue;
+  }
+
+  from(databaseValue: string): number {
+    return parseInt(databaseValue, 10);
+  }
+}

--- a/libs/entity/domain/user/User.entity.ts
+++ b/libs/entity/domain/user/User.entity.ts
@@ -1,0 +1,40 @@
+import { Exclude } from 'class-transformer';
+import { Column, Entity, OneToMany } from 'typeorm';
+import { BaseTimeEntity } from '../BaseTimeEntity';
+import { Product } from '../product/Product.entity';
+import { Purchase } from '../purchase/Purchase.entity';
+
+@Entity()
+export class User extends BaseTimeEntity {
+  @Column({
+    unique: true,
+    nullable: false,
+  })
+  account: string;
+
+  @Column({
+    nullable: false,
+  })
+  @Exclude()
+  password: string;
+
+  @Column({
+    nullable: false,
+  })
+  role: string;
+
+  @Column({
+    nullable: true,
+    type: 'timestamp',
+  })
+  loggedAt: Date | null;
+
+  @OneToMany(() => Product, (product: Product) => product.Author)
+  ProductOwner: Product[];
+
+  @OneToMany(() => Product, (product: Product) => product.Editor)
+  ProductInspect: Product[];
+
+  @OneToMany(() => Purchase, (purchase: Purchase) => purchase.User)
+  Purchase: Purchase[];
+}

--- a/libs/entity/domain/user/User.module.ts
+++ b/libs/entity/domain/user/User.module.ts
@@ -1,0 +1,11 @@
+import { User } from '@app/entity/domain/user/User.entity';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([User])],
+  exports: [TypeOrmModule],
+  providers: [],
+  controllers: [],
+})
+export class UserModule {}

--- a/libs/entity/getTypeOrmModule.ts
+++ b/libs/entity/getTypeOrmModule.ts
@@ -1,0 +1,6 @@
+import { ConfigService } from './config/configService';
+import { TypeOrmModule } from '@nestjs/typeorm';
+
+export function getTypeOrmModule() {
+  return TypeOrmModule.forRoot(ConfigService.ormConfig());
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "class-validator": "^0.13.2",
         "express-basic-auth": "^1.2.1",
         "joi": "^17.6.0",
+        "js-joda": "^1.11.0",
         "mysql2": "^2.3.3",
         "nest-winston": "^1.6.2",
         "reflect-metadata": "^0.1.13",
@@ -6354,6 +6355,12 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "node_modules/js-joda": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/js-joda/-/js-joda-1.11.0.tgz",
+      "integrity": "sha512-/HJpRhwP2fPyuSsCaZuoVJuaSIt8tUXykV4wOMRXrFk7RP9h9VWaFdS9YHKdMepxb/3TdXpL6IhfC9L0sqYVBw==",
+      "deprecated": "This package is deprecated, please check/use @js-joda/core instead"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -14578,6 +14585,11 @@
         "@sideway/formula": "^3.0.0",
         "@sideway/pinpoint": "^2.0.0"
       }
+    },
+    "js-joda": {
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/js-joda/-/js-joda-1.11.0.tgz",
+      "integrity": "sha512-/HJpRhwP2fPyuSsCaZuoVJuaSIt8tUXykV4wOMRXrFk7RP9h9VWaFdS9YHKdMepxb/3TdXpL6IhfC9L0sqYVBw=="
     },
     "js-tokens": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,11 +21,13 @@
         "class-validator": "^0.13.2",
         "express-basic-auth": "^1.2.1",
         "joi": "^17.6.0",
+        "mysql2": "^2.3.3",
         "nest-winston": "^1.6.2",
         "reflect-metadata": "^0.1.13",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
         "swagger-ui-express": "^4.4.0",
+        "typeorm-naming-strategies": "^4.1.0",
         "winston": "^3.7.2"
       },
       "devDependencies": {
@@ -3636,6 +3638,14 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ==",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4820,6 +4830,14 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "node_modules/generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "dependencies": {
+        "is-property": "^1.0.2"
+      }
+    },
     "node_modules/gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -5334,6 +5352,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "node_modules/is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -6604,11 +6627,15 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "node_modules/long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -6855,6 +6882,35 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "node_modules/mysql2": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
+      "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
+      "dependencies": {
+        "denque": "^2.0.1",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^4.0.0",
+        "lru-cache": "^6.0.0",
+        "named-placeholders": "^1.1.2",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "engines": {
+        "node": ">= 8.0"
+      }
+    },
+    "node_modules/mysql2/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -6865,6 +6921,31 @@
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
       }
+    },
+    "node_modules/named-placeholders": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
+      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
+      "dependencies": {
+        "lru-cache": "^4.1.3"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/lru-cache": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+      "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+      "dependencies": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
+    },
+    "node_modules/named-placeholders/node_modules/yallist": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -7417,6 +7498,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "node_modules/psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -7870,6 +7956,11 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
+    "node_modules/seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -8035,6 +8126,14 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "node_modules/sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg==",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/stack-trace": {
       "version": "0.0.10",
@@ -8961,6 +9060,14 @@
         }
       }
     },
+    "node_modules/typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "peerDependencies": {
+        "typeorm": "^0.2.0 || ^0.3.0"
+      }
+    },
     "node_modules/typeorm/node_modules/buffer": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
@@ -9565,8 +9672,7 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yaml": {
       "version": "1.10.2",
@@ -12406,6 +12512,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
+    "denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
+    },
     "depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -13321,6 +13432,14 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "generate-function": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.3.1.tgz",
+      "integrity": "sha512-eeB5GfMNeevm/GRYq20ShmsaGcmI81kIX2K9XQx5miC8KdHaC6Jm0qQ8ZNeGOi7wYB8OsdxKs+Y2oVuTFuVwKQ==",
+      "requires": {
+        "is-property": "^1.0.2"
+      }
+    },
     "gensync": {
       "version": "1.0.0-beta.2",
       "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -13685,6 +13804,11 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
       "integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ=="
+    },
+    "is-property": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+      "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
     },
     "is-stream": {
       "version": "2.0.1",
@@ -14673,11 +14797,15 @@
         "triple-beam": "^1.3.0"
       }
     },
+    "long": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
+      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+    },
     "lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -14869,6 +14997,31 @@
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
     },
+    "mysql2": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/mysql2/-/mysql2-2.3.3.tgz",
+      "integrity": "sha512-wxJUev6LgMSgACDkb/InIFxDprRa6T95+VEoR+xPvtngtccNH2dGjEB/fVZ8yg1gWv1510c9CvXuJHi5zUm0ZA==",
+      "requires": {
+        "denque": "^2.0.1",
+        "generate-function": "^2.3.1",
+        "iconv-lite": "^0.6.3",
+        "long": "^4.0.0",
+        "lru-cache": "^6.0.0",
+        "named-placeholders": "^1.1.2",
+        "seq-queue": "^0.0.5",
+        "sqlstring": "^2.3.2"
+      },
+      "dependencies": {
+        "iconv-lite": {
+          "version": "0.6.3",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+          "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+          "requires": {
+            "safer-buffer": ">= 2.1.2 < 3.0.0"
+          }
+        }
+      }
+    },
     "mz": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
@@ -14878,6 +15031,30 @@
         "any-promise": "^1.0.0",
         "object-assign": "^4.0.1",
         "thenify-all": "^1.0.0"
+      }
+    },
+    "named-placeholders": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/named-placeholders/-/named-placeholders-1.1.2.tgz",
+      "integrity": "sha512-wiFWqxoLL3PGVReSZpjLVxyJ1bRqe+KKJVbr4hGs1KWfTZTQyezHFBbuKj9hsizHyGV2ne7EMjHdxEGAybD5SA==",
+      "requires": {
+        "lru-cache": "^4.1.3"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "4.1.5",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
+          "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
+          "requires": {
+            "pseudomap": "^1.0.2",
+            "yallist": "^2.1.2"
+          }
+        },
+        "yallist": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+          "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+        }
       }
     },
     "natural-compare": {
@@ -15290,6 +15467,11 @@
         "ipaddr.js": "1.9.1"
       }
     },
+    "pseudomap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+    },
     "psl": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
@@ -15614,6 +15796,11 @@
         }
       }
     },
+    "seq-queue": {
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/seq-queue/-/seq-queue-0.0.5.tgz",
+      "integrity": "sha1-1WgS4cAXpuTnw+Ojeh2m143TyT4="
+    },
     "serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -15753,6 +15940,11 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
       "dev": true
+    },
+    "sqlstring": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/sqlstring/-/sqlstring-2.3.3.tgz",
+      "integrity": "sha512-qC9iz2FlN7DQl3+wjwn3802RTyjCx7sDvfQEXchwa6CWOx07/WVfh91gBmQ9fahw8snwGEWU3xGzOt4tFyHLxg=="
     },
     "stack-trace": {
       "version": "0.0.10",
@@ -16436,6 +16628,12 @@
         }
       }
     },
+    "typeorm-naming-strategies": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/typeorm-naming-strategies/-/typeorm-naming-strategies-4.1.0.tgz",
+      "integrity": "sha512-vPekJXzZOTZrdDvTl1YoM+w+sUIfQHG4kZTpbFYoTsufyv9NIBRe4Q+PdzhEAFA2std3D9LZHEb1EjE9zhRpiQ==",
+      "requires": {}
+    },
     "typescript": {
       "version": "4.7.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.2.tgz",
@@ -16832,8 +17030,7 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "dev": true
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yaml": {
       "version": "1.10.2",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
     "test:e2e": "jest --config ./test/jest-e2e.json",
-    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js --config ./libs/entity/config/ormConfig.ts",
+    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js --config ./libs/entity/config/migrateConfig.ts",
     "typeorm:create": "npm run typeorm migration:create -- -n",
     "typeorm:migrate": "npm run typeorm migration:generate -- -n",
     "typeorm:run": "npm run typeorm migration:run",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
-    "test:e2e": "jest --config ./test/jest-e2e.json"
+    "test:e2e": "jest --config ./test/jest-e2e.json",
+    "typeorm": "node --require ts-node/register ./node_modules/typeorm/cli.js --config ./libs/entity/config/ormConfig.ts",
+    "typeorm:create": "npm run typeorm migration:create -- -n",
+    "typeorm:migrate": "npm run typeorm migration:generate -- -n",
+    "typeorm:run": "npm run typeorm migration:run",
+    "typeorm:revert": "npm run typeorm migration:revert"
   },
   "dependencies": {
     "@nestjs/axios": "^0.0.8",
@@ -33,11 +38,13 @@
     "class-validator": "^0.13.2",
     "express-basic-auth": "^1.2.1",
     "joi": "^17.6.0",
+    "mysql2": "^2.3.3",
     "nest-winston": "^1.6.2",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
     "swagger-ui-express": "^4.4.0",
+    "typeorm-naming-strategies": "^4.1.0",
     "winston": "^3.7.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "class-validator": "^0.13.2",
     "express-basic-auth": "^1.2.1",
     "joi": "^17.6.0",
+    "js-joda": "^1.11.0",
     "mysql2": "^2.3.3",
     "nest-winston": "^1.6.2",
     "reflect-metadata": "^0.1.13",

--- a/src/HealthCheck/HealthCheckController.ts
+++ b/src/HealthCheck/HealthCheckController.ts
@@ -10,7 +10,8 @@ import {
 export class HealthCheckController {
   constructor(
     private health: HealthCheckService,
-    private http: HttpHealthIndicator, // private db: TypeOrmHealthIndicator,
+    private http: HttpHealthIndicator,
+    private db: TypeOrmHealthIndicator,
   ) {}
 
   @Get()
@@ -18,7 +19,7 @@ export class HealthCheckController {
   check() {
     return this.health.check([
       () => this.http.pingCheck('nestjs-axios', 'https://docs.nestjs.com'),
-      // () => this.db.pingCheck('database'),
+      () => this.db.pingCheck('database'),
     ]);
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -5,6 +5,7 @@ import { HealthCheckController } from './HealthCheck/HealthCheckController';
 import { TerminusModule } from '@nestjs/terminus';
 import { ValidationSchema } from '@app/common/config/validationSchema';
 import { LoggingModule } from '@app/common/logging/logging.module';
+import { getTypeOrmModule } from '@app/entity/getTypeOrmModule';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { LoggingModule } from '@app/common/logging/logging.module';
     HttpModule,
     TerminusModule,
     LoggingModule,
+    getTypeOrmModule(),
   ],
   controllers: [HealthCheckController],
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,8 +29,8 @@ class Application {
       expressBasicAuth({
         challenge: true,
         users: {
-          [ConfigService.swaggerAdminAuth().ADMIN_USER]:
-            ConfigService.swaggerAdminAuth().ADMIN_PASSWORD,
+          [ConfigService.swaggerAdminAuth().SWAGGER_ADMIN]:
+            ConfigService.swaggerAdminAuth().SWAGGER_PASSWORD,
         },
       }),
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,10 +21,10 @@
     "moduleResolution": "Node",
     "paths": {
       "@app/entity": [
-        "libs/entity/src"
+        "libs/entity"
       ],
       "@app/entity/*": [
-        "libs/entity/src/*"
+        "libs/entity/*"
       ],
       "@app/common": [
         "libs/common"


### PR DESCRIPTION
## DB Config
- Config Service 에 Env DB 세팅값 읽어올 수 있도록 추가
- 로컬 개발환경과 배포환경을 나눠서 처리할수 있도록 구현


## DB 설계
![스크린샷 2022-05-30 오전 10 56 25](https://user-images.githubusercontent.com/69755603/170903551-b0e63c6f-3ac9-433f-9aa3-04c5a7dd9950.png)

- Base Entity 생성하여 모든 테이블에 PK, created_at, updated_at 가지도록 구현
- TypeORM 관계 설정 
- Table 명은 SnakeNaming Strategy 활용 
- TypeORM Migration Script 추가 > DB 수정시 활용

